### PR TITLE
Update homebrew formula for Cargonode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/deployment

--- a/pkg/brew/cargonode.rb
+++ b/pkg/brew/cargonode.rb
@@ -1,20 +1,18 @@
-class cargonodeBin < Formula
+class Cargonode < Formula
     version '0.1.0'
-    desc "Revolutionize Node.js development workflows."
+    desc "Streamline Node.js development workflows"
     homepage "https://github.com/xosnrdev/cargonode"
   
     if OS.mac?
         url "https://github.com/xosnrdev/cargonode/releases/download/#{version}/cargonode-#{version}-x86_64-apple-darwin.tar.gz"
-        sha256 ""
+        sha256 "879d120c3b15cd1cd87fa0b3f4dc4fa54ad6c632712d9a8646be7697863fbb45"
     elsif OS.linux?
         url "https://github.com/xosnrdev/cargonode/releases/download/#{version}/cargonode-#{version}-x86_64-unknown-linux-musl.tar.gz"
-        sha256 ""
+        sha256 "eda2b34b131071a7ae5e8e30df13b7883a63d06038a26ecbb729c376d7df34fe"
     end
-  
-    conflicts_with "cargonode"
   
     def install
       bin.install "cargonode"
-      man1.install "doc/cargonode.1"
     end
-  end
+
+end


### PR DESCRIPTION
This pull request updates the homebrew formula for Cargonode. The changes include preparing the homebrew tap and updating the file paths in the formula. The new version of Cargonode is 0.1.0, and the download URLs and SHA256 hashes have been updated accordingly.