### PR TITLE
Delegate help to external tools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,15 +20,35 @@ enum Commands {
     /// Initialize package in current directory
     Init,
     /// Format files using biomejs
-    Fmt { args: Vec<String> },
+    #[command(disable_help_flag = true)]
+    Fmt {
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        args: Vec<String>,
+    },
     /// Check files using biomejs
-    Check { args: Vec<String> },
+    #[command(disable_help_flag = true)]
+    Check {
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        args: Vec<String>,
+    },
     /// Build and bundle using tsup
-    Build { args: Vec<String> },
+    #[command(disable_help_flag = true)]
+    Build {
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        args: Vec<String>,
+    },
     /// Run tests using vitest
-    Test { args: Vec<String> },
+    #[command(disable_help_flag = true)]
+    Test {
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        args: Vec<String>,
+    },
     /// Automate package release using release-it
-    Release { args: Vec<String> },
+    #[command(disable_help_flag = true)]
+    Release {
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        args: Vec<String>,
+    },
 }
 
 #[cfg(all(target_env = "musl", target_pointer_width = "64"))]


### PR DESCRIPTION
The pull request fixes the issue of cargonode --help overriding the native help messages of integrated external tools with generic help output. It ensures that help commands delegate to the integrated tool's native help system. The pull request includes changes to the CLI commands to pass help flags to the integrated tools instead of showing a generic help message. This fix allows users to access the documentation and options of the integrated tools, providing command-specific information.

Fixes #2.