### PR TITLE
Refactor code and drop once_cell deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,6 @@ dependencies = [
  "clap",
  "fs_extra",
  "jemallocator",
- "once_cell",
  "serde",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ name = "cargonode"
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }
 fs_extra = "1.3.0"
-once_cell = "1.20.2"
 serde = { version = "1.0.215", features = ["derive"] }
 tempfile = "3.14.0"
 toml = "0.8.19"

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,5 +1,3 @@
-//! Provides utilities for running shell commands and handling their output.
-
 use std::{
     fmt, io,
     path::{Path, PathBuf},

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1,5 +1,3 @@
-//! Provides configuration management and command execution utilities for the CargoNode tool.
-
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, fs, path::Path, result};

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1,6 +1,5 @@
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt, fs, path::Path, result};
+use std::{collections::HashMap, fmt, fs, path::Path, result, sync::LazyLock};
 
 use crate::exec;
 
@@ -185,7 +184,7 @@ impl Config {
 type Result<T> = result::Result<T, Error>;
 
 /// Stores the global configuration loaded from the configuration file.
-static CONFIG: Lazy<Config> = Lazy::new(Config::load);
+static CONFIG: LazyLock<Config> = LazyLock::new(Config::load);
 
 /// Executes the specified command in the given working directory with optional additional arguments.
 fn execute(work_dir: &Path, command: Command, extra_args: Vec<String>) -> Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
-/// Module responsible for executing external commands and processes.
 pub mod exec;
 
-/// Module containing integration-related functionality and logic.
 mod integration;
 
-/// Module for handling package-related operations.
 pub mod package;
 
 pub use integration::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+//! Unified tooling for Node.js
 use cargonode::{
     build, check, format,
     package::{get_current_dir, get_current_dir_name, Config, Package, Template},
@@ -5,7 +6,6 @@ use cargonode::{
 };
 use clap::{Parser, Subcommand};
 
-/// Unified Command-line interface.
 #[derive(Debug, Parser)]
 #[command(about, version, long_about = None)]
 struct Cli {
@@ -55,7 +55,6 @@ enum Commands {
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-/// Main function for parsing CLI commands and executing respective actions.
 fn main() {
     let cli = Cli::parse();
     let current_dir = get_current_dir();
@@ -76,7 +75,6 @@ fn main() {
         }};
     }
 
-    /// Macro for handling commands with the specified function.
     macro_rules! handle_command {
         ($cmd:expr, $func:expr) => {
             match $func(&current_dir, $cmd) {
@@ -86,7 +84,6 @@ fn main() {
         };
     }
 
-    // Map CLI commands to respective actions.
     match cli.command {
         Commands::New { package_name } => {
             create_package!(package_name, current_dir, create_package)


### PR DESCRIPTION
This pull request includes two commits. The first commit removes unnecessary documentation comments from source files. The second commit drops the `once_cell` crate for `std sync LazyLock` in the integration module. These changes improve the code by removing unnecessary dependencies and simplifying the codebase.