### PR TITLE
Refactor installation script and CI workflow

### DIFF
--- a/.github/workflows/ci_installation.yml
+++ b/.github/workflows/ci_installation.yml
@@ -13,13 +13,7 @@ on:
 
 jobs:
   install-test:
-    # Step 1: define a build matrix
-    # macOS removed, as installation is handled via Homebrew
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repo
@@ -30,24 +24,16 @@ jobs:
           uname -a
           echo "OS: ${{ runner.os }}"
 
-      # Step 2: Install dependencies (Linux only).
-      # For Windows, the built-in environment typically has curl, etc.
       - name: Install Dependencies (Linux)
-        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y dpkg zip curl unzip
 
-      # Step 3: Run the install script
-      # We attempt to install a specific version or use the default
       - name: Install cargonode
         run: |
           chmod +x ./install_cargonode.sh
           ./install_cargonode.sh --verbose --force
-        shell: bash
 
-      # Step 4: Verify that cargonode is installed and on PATH
       - name: Verify installation
         run: |
           cargonode --version
-        shell: bash

--- a/.github/workflows/ci_installation.yml
+++ b/.github/workflows/ci_installation.yml
@@ -12,17 +12,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  install-test:
+  test-installer:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-
-      - name: Show environment details
-        run: |
-          uname -a
-          echo "OS: ${{ runner.os }}"
 
       - name: Install Dependencies (Linux)
         run: |

--- a/.github/workflows/ci_installation.yml
+++ b/.github/workflows/ci_installation.yml
@@ -14,26 +14,24 @@ on:
 jobs:
   install-test:
     # Step 1: define a build matrix
+    # macOS removed, as installation is handled via Homebrew
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        # For demonstration, one can also include multiple “versions” or arch
-        # but for GitHub-hosted runners, you only have x86_64. We'll show how
-        # to handle musl or ARM via Docker in a separate job.
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Show environment details
         run: |
           uname -a
           echo "OS: ${{ runner.os }}"
 
-      # Step 2: Install dependencies
-      # (e.g., for Linux, we might need dpkg, shasum, etc.)
+      # Step 2: Install dependencies (Linux only).
+      # For Windows, the built-in environment typically has curl, etc.
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -41,7 +39,7 @@ jobs:
           sudo apt-get install -y dpkg zip curl unzip
 
       # Step 3: Run the install script
-      # We attempt to install a *specific version* or use the default.
+      # We attempt to install a specific version or use the default
       - name: Install cargonode
         run: |
           chmod +x ./install_cargonode.sh

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@
 
 Choose the option that fits your environment:
 
-1. **Shell Installer**
+1. **Shell Installer (Linux)**
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/xosnrdev/cargonode/master/install_cargonode.sh | sh
+   curl -fsSL https://raw.githubusercontent.com/xosnrdev/cargonode/master/install_cargonode.sh | bash
    ```
 
    Downloads the latest release from GitHub and installs locally, typically in `~/.local/bin`.

--- a/install_cargonode.sh
+++ b/install_cargonode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
This pull request includes several commits that aim to improve the installation script (`install_cargonode.sh`) and the CI workflow. The installation script has been refactored to enhance clarity, compatibility, and maintainability. It now specifies support for Linux installations, while macOS users are directed to use Homebrew and Windows users to use Scoop. The CI workflow has been streamlined by removing macOS from the build matrix and updating comments for better understanding of the installation steps. Additionally, the CI job has been renamed for better clarity, and unnecessary steps have been removed from the workflow. These changes aim to improve the user experience and streamline the installation process.