### PR TITLE
Fix toolchain error for wasm32-wasi target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - name: Add wasm32-wasi target
-        run: rustup target add wasm32-wasi
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
       - name: Basic build
         run: cargo build --verbose
 


### PR DESCRIPTION
# Description

Fixed the toolchain error where 'stable-x86_64-unknown-linux-gnu' did not support the 'wasm32-wasi' target. Updated to 'wasm32-wasip1' target for compatibility.

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan (required)
N/A

## Screenshots/Screencaps

N/A