### PR TITLE
Add centralized error module with `anyhow` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +141,7 @@ dependencies = [
 name = "cargonode"
 version = "0.1.3"
 dependencies = [
+ "anyhow",
  "clap",
  "fs_extra",
  "jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ homepage = "https://github.com/xosnrdev/cargonode?tab=readme-ov-file#readme"
 name = "cargonode"
 
 [dependencies]
+anyhow = "1.0.95"
 clap = { version = "4.5.26", features = ["derive"] }
 fs_extra = "1.3.0"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,60 @@
+#[derive(Debug)]
+pub struct CliError {
+    error: Option<anyhow::Error>,
+    code: i32,
+}
+
+impl CliError {
+    pub fn silent_with_code(code: i32) -> Self {
+        Self { error: None, code }
+    }
+
+    pub fn silent() -> Self {
+        Self::silent_with_code(0)
+    }
+
+    pub fn message_with_code(e: impl Into<anyhow::Error>, code: i32) -> Self {
+        Self {
+            error: Some(e.into()),
+            code,
+        }
+    }
+
+    pub fn message(e: impl Into<anyhow::Error>) -> Self {
+        Self::message_with_code(e, 101)
+    }
+}
+
+macro_rules! process_error_from {
+    ($from:ty) => {
+        impl From<$from> for CliError {
+            fn from(error: $from) -> Self {
+                Self::message(error)
+            }
+        }
+    };
+}
+
+process_error_from!(anyhow::Error);
+process_error_from!(std::io::Error);
+process_error_from!(std::string::FromUtf8Error);
+
+impl From<i32> for CliError {
+    fn from(code: i32) -> Self {
+        Self::silent_with_code(code)
+    }
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(error) = self.error.as_ref() {
+            error.fmt(f)
+        } else {
+            write!(f, "Exit code: {}", self.code)
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+pub type AppResult<T> = anyhow::Result<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod exec;
 pub mod package;
 
 pub use integration::*;
+pub mod error;
 pub mod ui;


### PR DESCRIPTION
# Description

References #24

- Introduced `anyhow` crate for improved user-facing error.
- Created `error.rs` module containing the `CliError` struct and associated methods for error handling.
- Added error module to lib.

Note: This PR does not resolve the issue completely but functionality counterpart.

## Link to issue

https://github.com/xosnrdev/cargonode/issues/24

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Test plan (required)

N/A

## Screenshots/Screencaps

N/A